### PR TITLE
Create jitpack.yml [adds the ability to add the dependency without a file]

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+before_install:
+  - sdk install java 17.0.6-tem


### PR DESCRIPTION
You can now add MinetopiaVehicles API to a project without downloading the plugin:

[https://jitpack.io/#DolphlnDevelopment/MinetopiaVehicles](https://jitpack.io/#DolphlnDevelopment/MinetopiaVehicles)

```xml
	<repositories>
		<repository>
		    <id>jitpack.io</id>
		    <url>https://jitpack.io</url>
		</repository>
	</repositories>
	
	<dependency>
	    <groupId>com.github.DolphlnDevelopment</groupId>
	    <artifactId>MinetopiaVehicles</artifactId>
	    <version>0840c87b2b</version>
	</dependency>
```