### PR TITLE
1.21.X SUPPORT

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -196,7 +196,19 @@
     <dependency>
       <groupId>org.spigotmc..............</groupId>
       <artifactId>spigot</artifactId>
-      <version>1.21-R0.1-SNAPSHOT</version>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.spigotmc...............</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.21.3-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.spigotmc................</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.21.4-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -214,7 +226,7 @@
     <dependency>
       <groupId>me.clip</groupId>
       <artifactId>placeholderapi</artifactId>
-      <version>2.11.3</version>
+      <version>2.11.6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -232,7 +232,7 @@
     <dependency>
       <groupId>com.github.SkriptLang</groupId>
       <artifactId>Skript</artifactId>
-      <version>2.6.2</version>
+      <version>2.10.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>com.github.SkriptLang</groupId>
             <artifactId>Skript</artifactId>
-            <version>2.6.2</version>
+            <version>2.10.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,19 @@
         <dependency>
             <groupId>org.spigotmc..............</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc...............</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21.3-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc................</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -169,7 +181,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
@@ -186,7 +198,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.3</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/nl/mtvehicles/core/infrastructure/enums/ServerVersion.java
+++ b/src/main/java/nl/mtvehicles/core/infrastructure/enums/ServerVersion.java
@@ -67,10 +67,20 @@ public enum ServerVersion {
      */
     v1_20_R4,
     /**
-     * 1.21
+     * 1.21 and 1.21.1
      * @since 2.5.4
      */
-    v1_21_R1;
+    v1_21_R1,
+    /**
+     * 1.21.2 and 1.21.3
+     * @since 2.5.5
+     */
+    v1_21_R2,
+    /**
+     * 1.21.4
+     * @since 2.5.5
+     */
+    v1_21_R3;
 
     public boolean is1_12(){
         return this.equals(v1_12);
@@ -119,6 +129,10 @@ public enum ServerVersion {
     public boolean is1_20_R4(){return this.equals(v1_20_R4);}
 
     public boolean is1_21_R1(){return this.equals(v1_21_R1);}
+
+    public boolean is1_21_R2(){return this.equals(v1_21_R2);}
+
+    public boolean is1_21_R3(){return this.equals(v1_21_R3);}
 
     /**
      * Check whether the server version is older than the given one

--- a/src/main/java/nl/mtvehicles/core/infrastructure/modules/VersionModule.java
+++ b/src/main/java/nl/mtvehicles/core/infrastructure/modules/VersionModule.java
@@ -132,6 +132,14 @@ public class VersionModule {
             case "v1_21_R1":
                 returns = ServerVersion.v1_21_R1;
                 break;
+            case "1.21.3":
+            case "v1_21_R2":
+                returns = ServerVersion.v1_21_R2;
+                break;
+            case "1.21.4":
+            case "v1_21_R3":
+                returns = ServerVersion.v1_21_R3;
+                break;
 
         }
         return returns;
@@ -146,8 +154,8 @@ public class VersionModule {
     public boolean isSupportedVersion(){
 
         List<String> highestVersions = Arrays.asList(
-                "1.12.2", "1.13.2", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.6", "1.21.1",
-                "v1_21_R1", "v1_20_R4", "v1_19_R3", "v1_18_R2", "v1_17_R1", "v1_16_R3", "v1_15_R1", "v1_13_R2", "v1_12_R1"
+                "1.12.2", "1.13.2", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.6", "1.21.1", "1.21.3", "1.21.4",
+                "v1_21_R1", "v1_20_R4", "v1_19_R3", "v1_18_R2", "v1_17_R1", "v1_16_R3", "v1_15_R1", "v1_13_R2", "v1_12_R1", "v1_21_R2", "v1_21_R3"
 
         );
 

--- a/src/main/java/nl/mtvehicles/core/movement/MovementManager.java
+++ b/src/main/java/nl/mtvehicles/core/movement/MovementManager.java
@@ -28,5 +28,7 @@ public class MovementManager {
         else if (getServerVersion().is1_20_R3()) PacketHandler.movement_1_20_R3(player);
         else if (getServerVersion().is1_20_R4()) PacketHandler.movement_1_20_R4(player);
         else if (getServerVersion().is1_21_R1()) PacketHandler.movement_1_21_R1(player);
+        else if (getServerVersion().is1_21_R2()) PacketHandler.movement_1_21_R2(player);
+        else if (getServerVersion().is1_21_R3()) PacketHandler.movement_1_21_R3(player);
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/PacketHandler.java
+++ b/src/main/java/nl/mtvehicles/core/movement/PacketHandler.java
@@ -10,6 +10,7 @@ import nl.mtvehicles.core.infrastructure.annotations.ToDo;
 import nl.mtvehicles.core.infrastructure.annotations.VersionSpecific;
 import nl.mtvehicles.core.infrastructure.enums.ServerVersion;
 import nl.mtvehicles.core.movement.versions.VehicleMovement1_12;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.Field;
@@ -22,6 +23,122 @@ import static nl.mtvehicles.core.infrastructure.modules.VersionModule.getServerV
  */
 @VersionSpecific
 public class PacketHandler {
+
+    /**
+     * Packet handler for vehicle steering in 1.21.4
+     * @param player Player whose steering is being regarded
+     */
+    public static void movement_1_21_R3(Player player) {
+        ChannelDuplexHandler channelDuplexHandler = new ChannelDuplexHandler() {
+            private net.minecraft.network.protocol.game.PacketPlayInSteerVehicle lastPacket = null;
+            private int taskId = -1;
+
+            public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+                super.channelRead(channelHandlerContext, packet);
+                if (packet instanceof net.minecraft.network.protocol.game.PacketPlayInSteerVehicle) {
+                    net.minecraft.network.protocol.game.PacketPlayInSteerVehicle ppisv = (net.minecraft.network.protocol.game.PacketPlayInSteerVehicle) packet;
+                    lastPacket = ppisv;
+
+                    if (taskId != -1) {
+                        Bukkit.getScheduler().cancelTask(taskId);
+                    }
+
+                    taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(Main.instance, () -> {
+                        if (player.isInsideVehicle()) {
+                            VehicleMovement movement = new VehicleMovement();
+                            movement.vehicleMovement(player, lastPacket);
+                        } else {
+                            Bukkit.getScheduler().cancelTask(taskId);
+                            taskId = -1;
+                        }
+                    }, 0L, 1L);
+                }
+            }
+        };
+        Channel channel = null;
+        try {
+            Object entityPlayer = ((org.bukkit.craftbukkit.v1_21_R3.entity.CraftPlayer) player).getHandle();
+
+            Field playerConnectionField = entityPlayer.getClass().getField("f");
+            net.minecraft.server.network.PlayerConnection playerConnection = (net.minecraft.server.network.PlayerConnection) playerConnectionField.get(entityPlayer);
+            Field networkManagerField = net.minecraft.server.network.ServerCommonPacketListenerImpl.class.getDeclaredField("e");
+            networkManagerField.setAccessible(true);
+            net.minecraft.network.NetworkManager networkManager = (net.minecraft.network.NetworkManager) networkManagerField.get(playerConnection);
+            Field channelField = networkManager.getClass().getField("n");
+            channel = (Channel) channelField.get(networkManager);
+
+            channel.pipeline()
+                    .addBefore("packet_handler", player.getName(), channelDuplexHandler);
+        } catch (IllegalArgumentException e) { //in case of plugin reload, prevent duplicate handler name exception
+            if (channel == null) {
+                unexpectedException(e);
+                return;
+            }
+            if (!channel.pipeline().names().contains(player.getName())) return;
+            channel.pipeline().remove(player.getName());
+            movement_1_21_R3(player);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            unexpectedException(e);
+        }
+    }
+
+    /**
+     * Packet handler for vehicle steering in 1.21.2 and 1.21.3
+     * @param player Player whose steering is being regarded
+     */
+    public static void movement_1_21_R2(Player player) {
+        ChannelDuplexHandler channelDuplexHandler = new ChannelDuplexHandler() {
+            private net.minecraft.network.protocol.game.PacketPlayInSteerVehicle lastPacket = null;
+            private int taskId = -1;
+
+            public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+                super.channelRead(channelHandlerContext, packet);
+                if (packet instanceof net.minecraft.network.protocol.game.PacketPlayInSteerVehicle) {
+                    net.minecraft.network.protocol.game.PacketPlayInSteerVehicle ppisv = (net.minecraft.network.protocol.game.PacketPlayInSteerVehicle) packet;
+                    lastPacket = ppisv;
+
+                    if (taskId != -1) {
+                        Bukkit.getScheduler().cancelTask(taskId);
+                    }
+
+                    taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(Main.instance, () -> {
+                        if (player.isInsideVehicle()) {
+                            VehicleMovement movement = new VehicleMovement();
+                            movement.vehicleMovement(player, lastPacket);
+                        } else {
+                            Bukkit.getScheduler().cancelTask(taskId);
+                            taskId = -1;
+                        }
+                    }, 0L, 1L);
+                }
+            }
+        };
+        Channel channel = null;
+        try {
+            Object entityPlayer = ((org.bukkit.craftbukkit.v1_21_R2.entity.CraftPlayer) player).getHandle();
+
+            Field playerConnectionField = entityPlayer.getClass().getField("f");
+            net.minecraft.server.network.PlayerConnection playerConnection = (net.minecraft.server.network.PlayerConnection) playerConnectionField.get(entityPlayer);
+            Field networkManagerField = net.minecraft.server.network.ServerCommonPacketListenerImpl.class.getDeclaredField("e");
+            networkManagerField.setAccessible(true);
+            net.minecraft.network.NetworkManager networkManager = (net.minecraft.network.NetworkManager) networkManagerField.get(playerConnection);
+            Field channelField = networkManager.getClass().getField("n");
+            channel = (Channel) channelField.get(networkManager);
+
+            channel.pipeline()
+                    .addBefore("packet_handler", player.getName(), channelDuplexHandler);
+        } catch (IllegalArgumentException e) { //in case of plugin reload, prevent duplicate handler name exception
+            if (channel == null) {
+                unexpectedException(e);
+                return;
+            }
+            if (!channel.pipeline().names().contains(player.getName())) return;
+            channel.pipeline().remove(player.getName());
+            movement_1_21_R2(player);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            unexpectedException(e);
+        }
+    }
 
     /**
      * Packet handler for vehicle steering in 1.21.1

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement.java
@@ -692,6 +692,8 @@ public class VehicleMovement {
         else if (getServerVersion().is1_20_R3()) teleportSeat(((org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity) seat).getHandle(), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         else if (getServerVersion().is1_20_R4()) teleportSeat(((org.bukkit.craftbukkit.v1_20_R4.entity.CraftEntity) seat).getHandle(), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         else if (getServerVersion().is1_21_R1()) teleportSeat(((org.bukkit.craftbukkit.v1_21_R1.entity.CraftEntity) seat).getHandle(), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        else if (getServerVersion().is1_21_R2()) teleportSeat(((org.bukkit.craftbukkit.v1_21_R2.entity.CraftEntity) seat).getHandle(), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        else if (getServerVersion().is1_21_R3()) teleportSeat(((org.bukkit.craftbukkit.v1_21_R3.entity.CraftEntity) seat).getHandle(), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
     }
 
     /**
@@ -917,16 +919,23 @@ public class VehicleMovement {
     protected boolean steerIsJumping(){
         boolean isJumping = false;
         try {
-            String declaredMethod = "d";
+            if(getServerVersion().isOlderOrEqualTo(ServerVersion.v1_21_R1)){
+                
+                String declaredMethod = "d";
 
-            if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R2) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4))  {
-                declaredMethod = "e";
-            } else if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R4)) {
-                declaredMethod = "f";
+                if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R2) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4))  {
+                    declaredMethod = "e";
+                } else if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R4)) {
+                    declaredMethod = "f";
+                }
+                Method method = packet.getClass().getDeclaredMethod(declaredMethod);
+                isJumping = (Boolean) method.invoke(packet);
+            } else { // 1_21_R2 and newer
+            Object input = packet.getClass().getDeclaredMethod("b").invoke(packet);
+            
+            isJumping = (boolean) input.getClass().getDeclaredMethod("e").invoke(input);
             }
-
-            Method method = packet.getClass().getDeclaredMethod(declaredMethod);
-            isJumping = (Boolean) method.invoke(packet);
+            
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -940,14 +949,23 @@ public class VehicleMovement {
     protected float steerGetXxa(){
         float Xxa = 0;
         try {
-            String declaredMethod = "b";
+            if(getServerVersion().isOlderOrEqualTo(ServerVersion.v1_21_R1)){
+                String declaredMethod = "b";
 
-            if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_19_R3) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4)) {
-                declaredMethod = "a";
+                if (getServerVersion().isNewerOrEqualTo(ServerVersion.v1_19_R3) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4)) {
+                    declaredMethod = "a";
+                }
+
+                Method method = packet.getClass().getDeclaredMethod(declaredMethod);
+                Xxa = (float) method.invoke(packet);
+            } else { // 1_21_R2 and newer
+                Object input = packet.getClass().getDeclaredMethod("b").invoke(packet);
+                if ((boolean) input.getClass().getDeclaredMethod("c").invoke(input)) {
+                    Xxa = 1;
+                } else if ((boolean) input.getClass().getDeclaredMethod("d").invoke(input)) {
+                    Xxa = -1;
+                }
             }
-
-            Method method = packet.getClass().getDeclaredMethod(declaredMethod);
-            Xxa = (float) method.invoke(packet);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -961,16 +979,25 @@ public class VehicleMovement {
     protected float steerGetZza(){
         float Zza = 0;
         try {
-            String declaredMethod = "c";
+            if(getServerVersion().isOlderOrEqualTo(ServerVersion.v1_21_R1)){
+                String declaredMethod = "c";
 
-            if (VersionModule.getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R2) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4)) {
-                declaredMethod = "d";
-            } else if(getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R4)){
-                declaredMethod = "e";
+                if (VersionModule.getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R2) && getServerVersion().isOlderThan(ServerVersion.v1_20_R4)) {
+                    declaredMethod = "d";
+                } else if(getServerVersion().isNewerOrEqualTo(ServerVersion.v1_20_R4)){
+                    declaredMethod = "e";
+                }
+
+                Method method = packet.getClass().getDeclaredMethod(declaredMethod);
+                Zza = (float) method.invoke(packet);
+            } else { // 1_21_R2 and newer
+                Object input = packet.getClass().getDeclaredMethod("b").invoke(packet);
+                if ((boolean) input.getClass().getDeclaredMethod("a").invoke(input)) {
+                    Zza = 1;
+                } else if ((boolean) input.getClass().getDeclaredMethod("b").invoke(input)) {
+                    Zza = -1;
+                }
             }
-
-            Method method = packet.getClass().getDeclaredMethod(declaredMethod);
-            Zza = (float) method.invoke(packet);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Added support for :
- 1.21.2
- 1.21.3
- 1.21.4

For the two versions (1_21_R2 and 1_21_R3), the behaviour of PacketPlayInSteerVehicle has changed, the first big change is that it now works with an Input, with z s q d jump sneak and ctrl but we only need movement and space, and that the packet is no longer called all the time but only when there's an input "change", so what I've done is to call it at each tick while checking that it's still in the vehicle, to imitate the previous behaviour.


Also we need to update docs to update supported versions